### PR TITLE
Default titles to blank so bad URLs do not blow up

### DIFF
--- a/app/models/codemark_record.rb
+++ b/app/models/codemark_record.rb
@@ -25,6 +25,6 @@ class CodemarkRecord < ActiveRecord::Base
   end
 
   def title
-    attributes[:title] || resource.try(:title)
+    attributes['title'] || resource.try(:title)
   end
 end

--- a/app/models/link_record.rb
+++ b/app/models/link_record.rb
@@ -5,10 +5,15 @@ class LinkRecord < ActiveRecord::Base
   has_many :clicks
   belongs_to :author, :class_name => 'User', :foreign_key => :author_id
 
-  validates_presence_of :url, :host, :title
+  before_validation :default_title
+  validates_presence_of :url, :host
 
   def orphan?
     author_id.blank?
+  end
+
+  def default_title
+    self.title ||= ''
   end
 
   def update_author(author_id = nil)

--- a/spec/models/links_record_spec.rb
+++ b/spec/models/links_record_spec.rb
@@ -3,11 +3,16 @@ require 'spec_helper'
 describe LinkRecord do
   let(:valid_url) { "http://www.example.com" }
 
-  required_attributes = [:url, :host, :title]
+  required_attributes = [:url, :host]
   required_attributes.each do |attr|
     it "requires a #{attr}" do
       link = Fabricate.build(:link_record, attr => nil)
       link.should_not be_valid
     end
+  end
+
+  it 'coerces title to an empty string' do
+    link = LinkRecord.create(:url => 'http://www.google.com', :host => 'google.com')
+    link.title.should == ''
   end
 end


### PR DESCRIPTION
Bad links were being invalidated because they had no titles. Instead of changing the link fetcher/saver, I just changed it to not really mean it's an invalid link.
